### PR TITLE
Add python 3 support

### DIFF
--- a/govdelivery/api.py
+++ b/govdelivery/api.py
@@ -1,7 +1,10 @@
 import os
 import base64
 import requests
-import urlparse
+try:
+    import urlparse
+except ImportError:
+    import urllib.parse as urlparse
 from string import Template
 
 from . import xml_payloads


### PR DESCRIPTION
Just a tiny change that makes my python 3 tests pass in tox.  According to [this python3 porting site](http://python3porting.com/stdlib.html#urllib-urllib2-and-urlparse), there is no `six` support for the urlparse rename so we have to do it this uglier way.
